### PR TITLE
Fix: auth modes, tests

### DIFF
--- a/src/HPKE.php
+++ b/src/HPKE.php
@@ -246,7 +246,7 @@ class HPKE
         string                                   $info = ''
     ): Receiver {
         $shared_secret = $this->kem->withHPKE($this)->authDecaps($sk, $pk, $enc);
-        $recv = $this->keySchedule(Role::Receiver, Mode::Auth, $shared_secret, $info, $psk, $pskID);
+        $recv = $this->keySchedule(Role::Receiver, Mode::AuthPSK, $shared_secret, $info, $psk, $pskID);
         if (!$recv instanceof Receiver) {
             throw new TypeError();
         }

--- a/src/KEM/DiffieHellmanKEM.php
+++ b/src/KEM/DiffieHellmanKEM.php
@@ -250,7 +250,7 @@ class DiffieHellmanKEM implements KemInterface
         $kem_context = $enc .
             $encapsKey->serializeForHeader() .
             $decapsKey->getEncapsKey()->serializeForHeader();
-        $secret_length = $this->curve->secretLength();
+        $secret_length = $this->getSecretLength();
         $shared_secret = new SymmetricKey($this->kdf->extractAndExpand(
             $this->getSuiteId(), $dh, $kem_context, $secret_length
         ));
@@ -281,9 +281,9 @@ class DiffieHellmanKEM implements KemInterface
         $ephPublic = new EncapsKey($decapsKey->curve, $enc);
         $dh = $this->scalarMult($decapsKey, $ephPublic) . $this->scalarMult($decapsKey, $encapsKey);
         $kem_context = $enc .
-            $encapsKey->serializeForHeader() .
-            $decapsKey->getEncapsKey()->serializeForHeader();
-        $secret_length = $this->curve->secretLength();
+            $decapsKey->getEncapsKey()->serializeForHeader() .
+            $encapsKey->serializeForHeader();
+        $secret_length = $this->getSecretLength();
         return new SymmetricKey(
             $this->kdf->extractAndExpand($this->getSuiteId(), $dh, $kem_context, $secret_length)
         );

--- a/tests/Context/ReceiverTest.php
+++ b/tests/Context/ReceiverTest.php
@@ -2,6 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\HPKE\Tests\Context;
 
+use ParagonIE\HPKE\AEAD\AES128GCM;
+use ParagonIE\HPKE\AEAD\AES256GCM;
+use ParagonIE\HPKE\AEAD\ChaCha20Poly1305;
+use ParagonIE\HPKE\Context;
 use ParagonIE\HPKE\Context\Receiver;
 use ParagonIE\HPKE\HPKE;
 use ParagonIE\HPKE\HPKEException;
@@ -12,6 +16,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use SodiumException;
 
 #[CoversClass(Receiver::class)]
+#[CoversClass(Context::class)]
+#[CoversClass(AES128GCM::class)]
+#[CoversClass(AES256GCM::class)]
+#[CoversClass(ChaCha20Poly1305::class)]
 class ReceiverTest extends ContextTestCase
 {
     public static function makeContext(

--- a/tests/Context/SenderTest.php
+++ b/tests/Context/SenderTest.php
@@ -2,6 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\HPKE\Tests\Context;
 
+use ParagonIE\HPKE\AEAD\AES128GCM;
+use ParagonIE\HPKE\AEAD\AES256GCM;
+use ParagonIE\HPKE\AEAD\ChaCha20Poly1305;
+use ParagonIE\HPKE\Context;
 use ParagonIE\HPKE\Context\Sender;
 use ParagonIE\HPKE\HPKE;
 use ParagonIE\HPKE\HPKEException;
@@ -12,6 +16,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use SodiumException;
 
 #[CoversClass(Sender::class)]
+#[CoversClass(Context::class)]
+#[CoversClass(AES128GCM::class)]
+#[CoversClass(AES256GCM::class)]
+#[CoversClass(ChaCha20Poly1305::class)]
 class SenderTest extends ContextTestCase
 {
     public static function makeContext(

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,7 +2,9 @@
 declare(strict_types=1);
 namespace ParagonIE\HPKE\Tests;
 
+use ParagonIE\HPKE\AEAD\ExportOnly;
 use ParagonIE\HPKE\Factory;
+use ParagonIE\HPKE\Hash;
 use ParagonIE\HPKE\HPKE;
 use ParagonIE\HPKE\HPKEException;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -11,6 +13,12 @@ use PHPUnit\Framework\TestCase;
 use SodiumException;
 
 #[CoversClass(Factory::class)]
+#[CoversClass(ExportOnly::class)]
+#[CoversClass(HPKE::class)]
+#[CoversClass(Hash::class)]
+#[CoversClass(HKDF::class)]
+#[CoversClass(Curve::class)]
+#[CoversClass(DiffieHellmanKEM::class)]
 class FactoryTest extends TestCase
 {
     public static function factoryProvider(): array

--- a/tests/HPKETest.php
+++ b/tests/HPKETest.php
@@ -3,7 +3,18 @@ declare(strict_types=1);
 namespace ParagonIE\HPKE\Tests;
 
 use ParagonIE\HPKE\AEAD\{AES128GCM, AES256GCM, ChaCha20Poly1305, ExportOnly};
-use ParagonIE\HPKE\{Hash, HPKE, HPKEException, Interfaces\AEADInterface, Interfaces\KDFInterface, Tests\KEM\MockDHKEM};
+use ParagonIE\HPKE\{
+    Context,
+    Hash,
+    HPKE,
+    HPKEException,
+    Interfaces\AEADInterface,
+    Interfaces\KDFInterface,
+    SymmetricKey,
+    Tests\KEM\MockDHKEM,
+    Util
+};
+use ParagonIE\HPKE\Context\{Receiver, Sender};
 use ParagonIE\HPKE\KDF\HKDF;
 use ParagonIE\HPKE\KEM\{DHKEM\Curve, DHKEM\DecapsKey, DHKEM\EncapsKey, DiffieHellmanKEM};
 use PHPUnit\Framework\Attributes\{
@@ -14,6 +25,19 @@ use PHPUnit\Framework\TestCase;
 use SodiumException;
 
 #[CoversClass(HPKE::class)]
+#[CoversClass(AES128GCM::class)]
+#[CoversClass(AES256GCM::class)]
+#[CoversClass(Context::class)]
+#[CoversClass(Receiver::class)]
+#[CoversClass(Sender::class)]
+#[CoversClass(HKDF::class)]
+#[CoversClass(Curve::class)]
+#[CoversClass(DecapsKey::class)]
+#[CoversClass(EncapsKey::class)]
+#[CoversClass(DiffieHellmanKEM::class)]
+#[CoversClass(SymmetricKey::class)]
+#[CoversClass(ChaCha20Poly1305::class)]
+#[CoversClass(Util::class)]
 class HPKETest extends TestCase
 {
     public static function hpkeProvider(): array
@@ -267,6 +291,452 @@ class HPKETest extends TestCase
         ];
     }
 
+
+    public static function rfc9180PSKTestVectors(): array
+    {
+        $kdf_sha256 = new HKDF(Hash::Sha256);
+        $kdf_sha512 = new HKDF(Hash::Sha512);
+
+        $dhkem_x25519 = new MockDHKEM(Curve::X25519, $kdf_sha256);
+        $dhkem_p256 = new MockDHKEM(Curve::NistP256, $kdf_sha256);
+        $dhkem_p521 = new MockDHKEM(Curve::NistP521, $kdf_sha512);
+
+        $aes128 = new AES128GCM();
+        $aes256 = new AES256GCM();
+        $chapoly = new ChaCha20Poly1305();
+        $export = new ExportOnly();
+
+        return [
+            'DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_x25519, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '463426a9ffb42bb17dbe6044b9abd1d4e4d95f9041cef0e99d7824eef2b6f588',
+                    'pkRm' => '9fed7e8c17387560e92cc6462a68049657246a09bfa8ade7aefe589672016366',
+                    'skRm' => 'c5eb01eb457fe6c6f57577c5413b931550a162c71a03ac8d196babbd4e5ce0fd',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '0ad0950d9fb9588e59690b74f1237ecdf1d775cd60be2eca57af5a4b0471c91b',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => 'e52c6fed7f758d0cf7145689f21bc1be6ec9ea097fef4e959440012f4feb73fb611b946199e681f4cfc34db8ea'
+                    ],
+                ]
+            ],
+            'DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305' => [
+                new HPKE($dhkem_x25519, $kdf_sha256, $chapoly),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '0c35fdf49df7aa01cd330049332c40411ebba36e0c718ebc3edf5845795f6321',
+                    'pkRm' => '13640af826b722fc04feaa4de2f28fbd5ecc03623b317834e7ff4120dbe73062',
+                    'skRm' => '77d114e0212be51cb1d76fa99dd41cfd4d0166b08caa09074430a6c59ef17879',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '2261299c3f40a9afc133b969a97f05e95be2c514e54f3de26cbe5644ac735b04',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '4a177f9c0d6f15cfdf533fb65bf84aecdc6ab16b8b85b4cf65a370e07fc1d78d28fb073214525276f4a89608ff'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '57427244f6cc016cddf1c19c8973b4060aa13579b4c067fd5d93a5d74e32a90f',
+                    'pkRm' => '040d97419ae99f13007a93996648b2674e5260a8ebd2b822e84899cd52d87446ea394ca76223b76639eccdf00e1967db10ade37db4e7db476261fcc8df97c5ffd1',
+                    'skRm' => '438d8bcef33b89e0e9ae5eb0957c353c25a94584b0dd59c991372a75b43cb661',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04305d35563527bce037773d79a13deabed0e8e7cde61eecee403496959e89e4d0ca701726696d1485137ccb5341b3c1c7aaee90a4a02449725e744b1193b53b5f',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '90c4deb5b75318530194e4bb62f890b019b1397bbf9d0d6eb918890e1fb2be1ac2603193b60a49c2126b75d0eb'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '57427244f6cc016cddf1c19c8973b4060aa13579b4c067fd5d93a5d74e32a90f',
+                    'pkRm' => '040d97419ae99f13007a93996648b2674e5260a8ebd2b822e84899cd52d87446ea394ca76223b76639eccdf00e1967db10ade37db4e7db476261fcc8df97c5ffd1',
+                    'skRm' => '438d8bcef33b89e0e9ae5eb0957c353c25a94584b0dd59c991372a75b43cb661',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04305d35563527bce037773d79a13deabed0e8e7cde61eecee403496959e89e4d0ca701726696d1485137ccb5341b3c1c7aaee90a4a02449725e744b1193b53b5f',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '90c4deb5b75318530194e4bb62f890b019b1397bbf9d0d6eb918890e1fb2be1ac2603193b60a49c2126b75d0eb'
+                    ],
+                ]
+            ],
+                        'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '57427244f6cc016cddf1c19c8973b4060aa13579b4c067fd5d93a5d74e32a90f',
+                    'pkRm' => '040d97419ae99f13007a93996648b2674e5260a8ebd2b822e84899cd52d87446ea394ca76223b76639eccdf00e1967db10ade37db4e7db476261fcc8df97c5ffd1',
+                    'skRm' => '438d8bcef33b89e0e9ae5eb0957c353c25a94584b0dd59c991372a75b43cb661',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04305d35563527bce037773d79a13deabed0e8e7cde61eecee403496959e89e4d0ca701726696d1485137ccb5341b3c1c7aaee90a4a02449725e744b1193b53b5f',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '90c4deb5b75318530194e4bb62f890b019b1397bbf9d0d6eb918890e1fb2be1ac2603193b60a49c2126b75d0eb'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA512, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha512, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => 'a5901ff7d6931959c2755382ea40a4869b1dec3694ed3b009dda2d77dd488f18',
+                    'pkRm' => '043f5266fba0742db649e1043102b8a5afd114465156719cea90373229aabdd84d7f45dabfc1f55664b888a7e86d594853a6cccdc9b189b57839cbbe3b90b55873',
+                    'skRm' => 'bc6f0b5e22429e5ff47d5969003f3cae0f4fec50e23602e880038364f33b8522',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04a307934180ad5287f95525fe5bc6244285d7273c15e061f0f2efb211c35057f3079f6e0abae200992610b25f48b63aacfcb669106ddee8aa023feed301901371',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '57624b6e320d4aba0afd11f548780772932f502e2ba2a8068676b2a0d3b5129a45b9faa88de39e8306da41d4cc'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $chapoly),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '7d6e4e006cee68af9b3fdd583a0ee8962df9d59fab029997ee3f456cbc857904',
+                    'pkRm' => '041eb8f4f20ab72661af369ff3231a733672fa26f385ffb959fd1bae46bfda43ad55e2d573b880831381d9367417f554ce5b2134fbba5235b44db465feffc6189e',
+                    'skRm' => '12ecde2c8bc2d5d7ed2219c71f27e3943d92b344174436af833337c557c300b3',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04f336578b72ad7932fe867cc4d2d44a718a318037a0ec271163699cee653fa805c1fec955e562663e0c2061bb96a87d78892bff0cc0bad7906c2d998ebe1a7246',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '21433eaff24d7706f3ed5b9b2e709b07230e2b11df1f2b1fe07b3c70d5948a53d6fa5c8bed194020bd9df0877b'
+                    ],
+                ]
+            ],
+            'DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM' => [
+                new HPKE($dhkem_p521, $kdf_sha512, $aes256),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '012e5cfe0daf5fe2a1cd617f4c4bae7c86f1f527b3207f115e262a98cc65268ec88cb8645aec73b7aa0a472d0292502d1078e762646e0c093cf873243d12c39915f6',
+                    'pkRm' => '04006917e049a2be7e1482759fb067ddb94e9c4f7f5976f655088dec45246614ff924ed3b385fc2986c0ecc39d14f907bf837d7306aada59dd5889086125ecd038ead400603394b5d81f89ebfd556a898cc1d6a027e143d199d3db845cb91c5289fb26c5ff80832935b0e8dd08d37c6185a6f77683347e472d1edb6daa6bd7652fea628fae',
+                    'skRm' => '011bafd9c7a52e3e71afbdab0d2f31b03d998a0dc875dd7555c63560e142bde264428de03379863b4ec6138f813fa009927dc5d15f62314c56d4e7ff2b485753eb72',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '040085eff0835cc84351f32471d32aa453cdc1f6418eaaecf1c2824210eb1d48d0768b368110fab21407c324b8bb4bec63f042cfa4d0868d19b760eb4beba1bff793b30036d2c614d55730bd2a40c718f9466faf4d5f8170d22b6df98dfe0c067d02b349ae4a142e0c03418f0a1479ff78a3db07ae2c2e89e5840f712c174ba2118e90fdcb',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => 'de69e9d943a5d0b70be3359a19f317bd9aca4a2ebb4332a39bcdfc97d5fe62f3a77702f4822c3be531aa7843a1'
+                    ],
+                ]
+            ],
+        ];
+    }
+    public static function rfc9180AuthTestVectors(): array
+    {
+        $kdf_sha256 = new HKDF(Hash::Sha256);
+        $kdf_sha512 = new HKDF(Hash::Sha512);
+
+        $dhkem_x25519 = new MockDHKEM(Curve::X25519, $kdf_sha256);
+        $dhkem_p256 = new MockDHKEM(Curve::NistP256, $kdf_sha256);
+        $dhkem_p521 = new MockDHKEM(Curve::NistP521, $kdf_sha512);
+
+        $aes128 = new AES128GCM();
+        $aes256 = new AES256GCM();
+        $chapoly = new ChaCha20Poly1305();
+        $export = new ExportOnly();
+
+        return [
+            'DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_x25519, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => 'ff4442ef24fbc3c1ff86375b0be1e77e88a0de1e79b30896d73411c5ff4c3518',
+                    'pkRm' => '1632d5c2f71c2b38d0a8fcc359355200caa8b1ffdf28618080466c909cb69b2e',
+                    'skRm' => 'fdea67cf831f1ca98d8e27b1f6abeb5b7745e9d35348b80fa407ff6958f9137e',
+                    'pkSm' => '8b0c70873dc5aecb7f9ee4e62406a397b350e57012be45cf53b7105ae731790b',
+                    'skSm' => 'dc4a146313cce60a278a5323d321f051c5707e9c45ba21a3479fecdf76fc69dd',
+                    'enc'  => '23fb952571a14a25e3d678140cd0e5eb47a0961bb18afcf85896e5453c312e76',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '5fd92cc9d46dbf8943e72a07e42f363ed5f721212cd90bcfd072bfd9f44e06b80fd17824947496e21b680c141b'
+                    ],
+                ]
+            ],
+            'DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305' => [
+                new HPKE($dhkem_x25519, $kdf_sha256, $chapoly),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => 'c94619e1af28971c8fa7957192b7e62a71ca2dcdde0a7cc4a8a9e741d600ab13',
+                    'pkRm' => '1a478716d63cb2e16786ee93004486dc151e988b34b475043d3e0175bdb01c44',
+                    'skRm' => '3ca22a6d1cda1bb9480949ec5329d3bf0b080ca4c45879c95eddb55c70b80b82',
+                    'pkSm' => 'f0f4f9e96c54aeed3f323de8534fffd7e0577e4ce269896716bcb95643c8712b',
+                    'skSm' => '2def0cb58ffcf83d1062dd085c8aceca7f4c0c3fd05912d847b61f3e54121f05',
+                    'enc'  => 'f7674cc8cd7baa5872d1f33dbaffe3314239f6197ddf5ded1746760bfc847e0e',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => 'ab1a13c9d4f01a87ec3440dbd756e2677bd2ecf9df0ce7ed73869b98e00c09be111cb9fdf077347aeb88e61bdf'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '6b8de0873aed0c1b2d09b8c7ed54cbf24fdf1dfc7a47fa501f918810642d7b91',
+                    'pkRm' => '04423e363e1cd54ce7b7573110ac121399acbc9ed815fae03b72ffbd4c18b01836835c5a09513f28fc971b7266cfde2e96afe84bb0f266920e82c4f53b36e1a78d',
+                    'skRm' => 'd929ab4be2e59f6954d6bedd93e638f02d4046cef21115b00cdda2acb2a4440e',
+                    'pkSm' => '04a817a0902bf28e036d66add5d544cc3a0457eab150f104285df1e293b5c10eef8651213e43d9cd9086c80b309df22cf37609f58c1127f7607e85f210b2804f73',
+                    'skSm' => '1120ac99fb1fccc1e8230502d245719d1b217fe20505c7648795139d177f0de9',
+                    'enc'  => '042224f3ea800f7ec55c03f29fc9865f6ee27004f818fcbdc6dc68932c1e52e15b79e264a98f2c535ef06745f3d308624414153b22c7332bc1e691cb4af4d53454',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '82ffc8c44760db691a07c5627e5fc2c08e7a86979ee79b494a17cc3405446ac2bdb8f265db4a099ed3289ffe19'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA512 AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha512, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '93cddd5288e7ef4884c8fe321d075df01501b993ff49ffab8184116f39b3c655',
+                    'pkRm' => '04378bad519aab406e04d0e5608bcca809c02d6afd2272d4dd03e9357bd0eee8adf84c8deba3155c9cf9506d1d4c8bfefe3cf033a75716cc3cc07295100ec96276',
+                    'skRm' => '1ea4484be482bf25fdb2ed39e6a02ed9156b3e57dfb18dff82e4a048de990236',
+                    'pkSm' => '0404d3c1f9fca22eb4a6d326125f0814c35593b1da8ea0d11a640730b215a259b9b98a34ad17e21617d19fe1d4fa39a4828bfdb306b729ec51c543caca3b2d9529',
+                    'skSm' => '02b266d66919f7b08f42ae0e7d97af4ca98b2dae3043bb7e0740ccadc1957579',
+                    'enc'  => '04fec59fa9f76f5d0f6c1660bb179cb314ed97953c53a60ab38f8e6ace60fd59178084d0dd66e0f79172992d4ddb2e91172ce24949bcebfff158dcc417f2c6e9c6',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '2480179d880b5f458154b8bfe3c7e8732332de84aabf06fc440f6b31f169e154157fa9eb44f2fa4d7b38a9236e'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $chapoly),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '085fd5d5e6ce6497c79df960cac93710006b76217d8bcfafbd2bb2c20ea03c42',
+                    'pkRm' => '0444f6ee41818d9fe0f8265bffd016b7e2dd3964d610d0f7514244a60dbb7a11ece876bb110a97a2ac6a9542d7344bf7d2bd59345e3e75e497f7416cf38d296233',
+                    'skRm' => '3cb2c125b8c5a81d165a333048f5dcae29a2ab2072625adad66dbb0f48689af9',
+                    'pkSm' => '04265529a04d4f46ab6fa3af4943774a9f1127821656a75a35fade898a9a1b014f64d874e88cddb24c1c3d79004d3a587db67670ca357ff4fba7e8b56ec013b98b',
+                    'skSm' => '39b19402e742d48d319d24d68e494daa4492817342e593285944830320912519',
+                    'enc'  => '040d5176aedba55bc41709261e9195c5146bb62d783031280775f32e507d79b5cbc5748b6be6359760c73cfe10ca19521af704ca6d91ff32fc0739527b9385d415',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '25881f219935eec5ba70d7b421f13c35005734f3e4d959680270f55d71e2f5cb3bd2daced2770bf3d9d4916872'
+                    ],
+                ]
+            ],
+            'DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM' => [
+                new HPKE($dhkem_p521, $kdf_sha512, $aes256),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '0185f03560de87bb2c543ef03607f3c33ac09980000de25eabe3b224312946330d2e65d192d3b4aa46ca92fc5ca50736b624402d95f6a80dc04d1f10ae9517137261',
+                    'pkRm' => '04007d419b8834e7513d0e7cc66424a136ec5e11395ab353da324e3586673ee73d53ab34f30a0b42a92d054d0db321b80f6217e655e304f72793767c4231785c4a4a6e008f31b93b7a4f2b8cd12e5fe5a0523dc71353c66cbdad51c86b9e0bdfcd9a45698f2dab1809ab1b0f88f54227232c858accc44d9a8d41775ac026341564a2d749f4',
+                    'skRm' => '013ef326940998544a899e15e1726548ff43bbdb23a8587aa3bef9d1b857338d87287df5667037b519d6a14661e9503cfc95a154d93566d8c84e95ce93ad05293a0b',
+                    'pkSm' => '04015cc3636632ea9a3879e43240beae5d15a44fba819282fac26a19c989fafdd0f330b8521dff7dc393101b018c1e65b07be9f5fc9a28a1f450d6a541ee0d76221133001e8f0f6a05ab79f9b9bb9ccce142a453d59c5abebb5674839d935a3ca1a3fbc328539a60b3bc3c05fed22838584a726b9c176796cad0169ba4093332cbd2dc3a9f',
+                    'skSm' => '001018584599625ff9953b9305849850d5e34bd789d4b81101139662fbea8b6508ddb9d019b0d692e737f66beae3f1f783e744202aaf6fea01506c27287e359fe776',
+                    'enc'  => '04017de12ede7f72cb101dab36a111265c97b3654816dcd6183f809d4b3d111fe759497f8aefdc5dbb40d3e6d21db15bdc60f15f2a420761bcaeef73b891c2b117e9cf01e29320b799bbc86afdc5ea97d941ea1c5bd5ebeeac7a784b3bab524746f3e640ec26ee1bd91255f9330d974f845084637ee0e6fe9f505c5b87c86a4e1a6c3096dd',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '0116aeb3a1c405c61b1ce47600b7ecd11d89b9c08c408b7e2d1e00a4d64696d12e6881dc61688209a8207427f9'
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    public static function rfc9180AuthPSKTestVectors(): array
+    {
+        $kdf_sha256 = new HKDF(Hash::Sha256);
+        $kdf_sha512 = new HKDF(Hash::Sha512);
+
+        $dhkem_x25519 = new MockDHKEM(Curve::X25519, $kdf_sha256);
+        $dhkem_p256 = new MockDHKEM(Curve::NistP256, $kdf_sha256);
+        $dhkem_p521 = new MockDHKEM(Curve::NistP521, $kdf_sha512);
+
+        $aes128 = new AES128GCM();
+        $aes256 = new AES256GCM();
+        $chapoly = new ChaCha20Poly1305();
+        $export = new ExportOnly();
+
+        return [
+            'DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_x25519, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '14de82a5897b613616a00c39b87429df35bc2b426bcfd73febcb45e903490768',
+                    'pkRm' => '1d11a3cd247ae48e901939659bd4d79b6b959e1f3e7d66663fbc9412dd4e0976',
+                    'skRm' => 'cb29a95649dc5656c2d054c1aa0d3df0493155e9d5da6d7e344ed8b6a64a9423',
+                    'pkSm' => '2bfb2eb18fcad1af0e4f99142a1c474ae74e21b9425fc5c589382c69b50cc57e',
+                    'skSm' => 'fc1c87d2f3832adb178b431fce2ac77c7ca2fd680f3406c77b5ecdf818b119f4',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '820818d3c23993492cc5623ab437a48a0a7ca3e9639c140fe1e33811eb844b7c',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => 'a84c64df1e11d8fd11450039d4fe64ff0c8a99fca0bd72c2d4c3e0400bc14a40f27e45e141a24001697737533e'
+                    ],
+                ]
+            ],
+            'DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305' => [
+                new HPKE($dhkem_x25519, $kdf_sha256, $chapoly),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '5e6dd73e82b856339572b7245d3cbb073a7561c0bee52873490e305cbb710410',
+                    'pkRm' => 'a5099431c35c491ec62ca91df1525d6349cb8aa170c51f9581f8627be6334851',
+                    'skRm' => '7b36a42822e75bf3362dfabbe474b3016236408becb83b859a6909e22803cb0c',
+                    'pkSm' => '3ac5bd4dd66ff9f2740bef0d6ccb66daa77bff7849d7895182b07fb74d087c45',
+                    'skSm' => '90761c5b0a7ef0985ed66687ad708b921d9803d51637c8d1cb72d03ed0f64418',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '656a2e00dc9990fd189e6e473459392df556e9a2758754a09db3f51179a3fc02',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '9aa52e29274fc6172e38a4461361d2342585d3aeec67fb3b721ecd63f059577c7fe886be0ede01456ebc67d597'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '36f771e411cf9cf72f0701ef2b991ce9743645b472e835fe234fb4d6eb2ff5a0',
+                    'pkRm' => '04d824d7e897897c172ac8a9e862e4bd820133b8d090a9b188b8233a64dfbc5f725aa0aa52c8462ab7c9188f1c4872f0c99087a867e8a773a13df48a627058e1b3',
+                    'skRm' => 'bdf4e2e587afdf0930644a0c45053889ebcadeca662d7c755a353d5b4e2a8394',
+                    'pkSm' => '049f158c750e55d8d5ad13ede66cf6e79801634b7acadcad72044eac2ae1d0480069133d6488bf73863fa988c4ba8bde1c2e948b761274802b4d8012af4f13af9e',
+                    'skSm' => 'b0ed8721db6185435898650f7a677affce925aba7975a582653c4cb13c72d240',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '046a1de3fc26a3d43f4e4ba97dbe24f7e99181136129c48fbe872d4743e2b131357ed4f29a7b317dc22509c7b00991ae990bf65f8b236700c82ab7c11a84511401',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => 'b9f36d58d9eb101629a3e5a7b63d2ee4af42b3644209ab37e0a272d44365407db8e655c72e4fa46f4ff81b9246'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA512, AES-128-GCM' => [
+                new HPKE($dhkem_p256, $kdf_sha512, $aes128),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '778f2254ae5d661d5c7fca8c4a7495a25bd13f26258e459159f3899df0de76c1',
+                    'pkRm' => '04a4ca7af2fc2cce48edbf2f1700983e927743a4e85bb5035ad562043e25d9a111cbf6f7385fac55edc5c9d2ca6ed351a5643de95c36748e11dbec98730f4d43e9',
+                    'skRm' => '00510a70fde67af487c093234fc4215c1cdec09579c4b30cc8e48cb530414d0e',
+                    'pkSm' => '04b59a4157a9720eb749c95f842a5e3e8acdccbe834426d405509ac3191e23f2165b5bb1f07a6240dd567703ae75e13182ee0f69fc102145cdb5abf681ff126d60',
+                    'skSm' => 'd743b20821e6326f7a26684a4beed7088b35e392114480ca9f6c325079dcf10b',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04801740f4b1b35823f7fb2930eac2efc8c4893f34ba111c0bb976e3c7d5dc0aef5a7ef0bf4057949a140285f774f1efc53b3860936b92279a11b68395d898d138',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '840669634db51e28df54f189329c1b727fd303ae413f003020aff5e26276aaa910fc4296828cb9d862c2fd7d16'
+                    ],
+                ]
+            ],
+            'DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, ChaCha20Poly1305' => [
+                new HPKE($dhkem_p256, $kdf_sha256, $chapoly),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '11b7e4de2d919240616a31ab14944cced79bc2372108bb98f6792e3b645fe546',
+                    'pkRm' => '04d383fd920c42d018b9d57fd73a01f1eee480008923f67d35169478e55d2e8817068daf62a06b10e0aad4a9e429fa7f904481be96b79a9c231a33e956c20b81b6',
+                    'skRm' => 'c29fc577b7e74d525c0043f1c27540a1248e4f2c8d297298e99010a92e94865c',
+                    'pkSm' => '0492cf8c9b144b742fe5a63d9a181a19d416f3ec8705f24308ad316564823c344e018bd7c03a33c926bb271b28ef5bf28c0ca00abff249fee5ef7f33315ff34fdb',
+                    'skSm' => '53541bd995f874a67f8bfd8038afa67fd68876801f42ff47d0dc2a4deea067ae',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '043539917ee26f8ae0aa5f784a387981b13de33124a3cde88b94672030183110f331400115855808244ff0c5b6ca6104483ac95724481d41bdcd9f15b430ad16f6',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '9eadfa0f954835e7e920ffe56dec6b31a046271cf71fdda55db72926e1d8fae94cc6280fcfabd8db71eaa65c05'
+                    ],
+                ]
+            ],
+            'DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM' => [
+                new HPKE($dhkem_p521, $kdf_sha512, $aes256),
+                [
+                    'info' => '4f6465206f6e2061204772656369616e2055726e',
+                    'skEm' => '003430af19716084efeced1241bb1a5625b6c826f11ef31649095eb27952619e36f62a79ea28001ac452fb20ddfbb66e62c6c0b1be03c0d28c97794a1fb638207a83',
+                    'pkRm' => '0401655b5d3b7cfafaba30851d25edc44c6dd17d99410efbed8591303b4dbeea8cb1045d5255f9a60384c3bbd4a3386ae6e6fab341dc1f8db0eed5f0ab1aaac6d7838e00dadf8a1c2c64b48f89c633721e88369e54104b31368f26e35d04a442b0b428510fb23caada686add16492f333b0f7ba74c391d779b788df2c38d7a7f4778009d91',
+                    'skRm' => '0053c0bc8c1db4e9e5c3e3158bfdd7fc716aef12db13c8515adf821dd692ba3ca53041029128ee19c8556e345c4bcb840bb7fd789f97fe10f17f0e2c6c2528072843',
+                    'pkSm' => '040013761e97007293d57de70962876b4926f69a52680b4714bee1d4236aa96c19b840c57e80b14e91258f0a350e3f7ba59f3f091633aede4c7ec4fa8918323aa45d5901076dec8eeb22899fda9ab9e1960003ff0535f53c02c40f2ae4cdc6070a3870b85b4bdd0bb77f1f889e7ee51f465a308f08c666ad3407f75dc046b2ff5a24dbe2ed',
+                    'skSm' => '003f64675fc8914ec9e2b3ecf13585b26dbaf3d5d805042ba487a5070b8c5ac1d39b17e2161771cc1b4d0a3ba6e866f4ea4808684b56af2a49b5e5111146d45d9326',
+                    'psk' => '0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82',
+                    'psk_id' => '456e6e796e20447572696e206172616e204d6f726961',
+                    'enc'  => '04000a5096a6e6e002c83517b494bfc2e36bfb8632fae8068362852b70d0ff71e560b15aff96741ecffb63d8ac3090c3769679009ac59a99a1feb4713c5f090fc0dbed01ad73c45d29d369e36744e9ed37d12f80700c16d816485655169a5dd66e4ddf27f2acffe0f56f7f77ea2b473b4bf0518b975d9527009a3d14e5a4957e3e8a9074f8',
+                ],
+                [
+                    [
+                        'pt' => '4265617574792069732074727574682c20747275746820626561757479',
+                        'aad' => '436f756e742d30',
+                        'ct' => '942a2a92e0817cf032ce61abccf4f3a7c5d21b794ed943227e07b7df2d6dd92c9b8a9371949e65cca262448ab7'
+                    ],
+                ]
+            ],
+        ];
+    }
+
     /**
      * @throws HPKEException
      * @throws SodiumException
@@ -287,6 +757,145 @@ class HPKETest extends TestCase
         [$enc, $sender] = $hpke->setupBaseSender(new EncapsKey($dhkem->curve, $pkRm), $info);
         $this->assertSame($testVectorsHex['enc'], sodium_bin2hex($enc), 'enc');
         $receiver = $hpke->setupBaseReceiver(new DecapsKey($dhkem->curve, $skRm), $enc, $info);
+        foreach ($encryptions as $hexTests) {
+            $pt = sodium_hex2bin($hexTests['pt']);
+            $ct = sodium_hex2bin($hexTests['ct']);
+            $aad = sodium_hex2bin($hexTests['aad']);
+
+            $sealed = $sender->seal($pt, $aad);
+            $this->assertSame($hexTests['ct'], sodium_bin2hex($sealed), 'seal');
+            $opened = $receiver->open($ct, $aad);
+            $this->assertSame($hexTests['pt'], sodium_bin2hex($opened), 'open');
+        }
+    }
+
+    /**
+     * @throws HPKEException
+     * @throws SodiumException
+     */
+    #[DataProvider('rfc9180PSKTestVectors')]
+    public function testPSKVectorsRfc9180(HPKE $hpke, array $testVectorsHex, array $encryptions): void
+    {
+        /** @var MockDHKEM $dhkem */
+        $dhkem = $hpke->kem;
+
+        $dhkem->withHPKE($hpke);
+        $skEm = sodium_hex2bin($testVectorsHex['skEm']);
+        $pkRm = sodium_hex2bin($testVectorsHex['pkRm']);
+        $skRm = sodium_hex2bin($testVectorsHex['skRm']);
+        $psk = sodium_hex2bin($testVectorsHex['psk']);
+        $psk_id = sodium_hex2bin($testVectorsHex['psk_id']);
+        $info = sodium_hex2bin($testVectorsHex['info']);
+        $dhkem->setPrivateKey($skEm);
+
+        [$enc, $sender] = $hpke->setupPSKSender(
+            new EncapsKey($dhkem->curve, $pkRm),
+            $psk,
+            $psk_id,
+            $info
+        );
+        $this->assertSame($testVectorsHex['enc'], sodium_bin2hex($enc), 'enc');
+        $receiver = $hpke->setupPSKReceiver(
+            new DecapsKey($dhkem->curve, $skRm),
+            $enc,
+            $psk,
+            $psk_id,
+            $info
+        );
+        foreach ($encryptions as $hexTests) {
+            $pt = sodium_hex2bin($hexTests['pt']);
+            $ct = sodium_hex2bin($hexTests['ct']);
+            $aad = sodium_hex2bin($hexTests['aad']);
+
+            $sealed = $sender->seal($pt, $aad);
+            $this->assertSame($hexTests['ct'], sodium_bin2hex($sealed), 'seal');
+            $opened = $receiver->open($ct, $aad);
+            $this->assertSame($hexTests['pt'], sodium_bin2hex($opened), 'open');
+        }
+    }
+
+    /**
+     * @throws HPKEException
+     * @throws SodiumException
+     */
+    #[DataProvider('rfc9180AuthTestVectors')]
+    public function testAuthVectorsRfc9180(HPKE $hpke, array $testVectorsHex, array $encryptions): void
+    {
+        /** @var MockDHKEM $dhkem */
+        $dhkem = $hpke->kem;
+
+        $dhkem->withHPKE($hpke);
+        $skEm = sodium_hex2bin($testVectorsHex['skEm']);
+        $pkRm = sodium_hex2bin($testVectorsHex['pkRm']);
+        $skRm = sodium_hex2bin($testVectorsHex['skRm']);
+        $skSm = sodium_hex2bin($testVectorsHex['skSm']);
+        $pkSm = sodium_hex2bin($testVectorsHex['pkSm']);
+        $info = sodium_hex2bin($testVectorsHex['info']);
+        $dhkem->setPrivateKey($skEm);
+
+        [$enc, $sender] = $hpke->setupAuthSender(
+            new EncapsKey($dhkem->curve, $pkRm),
+            new DecapsKey($dhkem->curve, $skSm),
+            $info
+        );
+        $this->assertSame($testVectorsHex['enc'], sodium_bin2hex($enc), 'enc');
+        $receiver = $hpke->setupAuthReceiver(
+            new DecapsKey($dhkem->curve, $skRm),
+            new EncapsKey($dhkem->curve, $pkSm),
+            $enc,
+            $info
+        );
+        foreach ($encryptions as $hexTests) {
+            $pt = sodium_hex2bin($hexTests['pt']);
+            $ct = sodium_hex2bin($hexTests['ct']);
+            $aad = sodium_hex2bin($hexTests['aad']);
+
+            $sealed = $sender->seal($pt, $aad);
+            $this->assertSame($hexTests['ct'], sodium_bin2hex($sealed), 'seal');
+            $opened = $receiver->open($ct, $aad);
+            $this->assertSame($hexTests['pt'], sodium_bin2hex($opened), 'open');
+        }
+    }
+
+
+    /**
+     * @throws HPKEException
+     * @throws SodiumException
+     */
+    #[DataProvider('rfc9180AuthPSKTestVectors')]
+    public function testAuthPSKVectorsRfc9180(HPKE $hpke, array $testVectorsHex, array $encryptions): void
+    {
+        /** @var MockDHKEM $dhkem */
+        $dhkem = $hpke->kem;
+
+        $dhkem->withHPKE($hpke);
+        $skEm = sodium_hex2bin($testVectorsHex['skEm']);
+        $pkRm = sodium_hex2bin($testVectorsHex['pkRm']);
+        $skRm = sodium_hex2bin($testVectorsHex['skRm']);
+        $skSm = sodium_hex2bin($testVectorsHex['skSm']);
+        $pkSm = sodium_hex2bin($testVectorsHex['pkSm']);
+        $psk = sodium_hex2bin($testVectorsHex['psk']);
+        $psk_id = sodium_hex2bin($testVectorsHex['psk_id']);
+        $info = sodium_hex2bin($testVectorsHex['info']);
+        $dhkem->setPrivateKey($skEm);
+
+        [$enc, $sender] = $hpke->setupAuthPSKSender(
+            new EncapsKey($dhkem->curve, $pkRm),
+            new DecapsKey($dhkem->curve, $skSm),
+            $psk,
+            $psk_id,
+            $info
+        );
+        $this->assertSame($testVectorsHex['enc'], sodium_bin2hex($enc), 'enc');
+        $receiver = $hpke->setupAuthPSKReceiver(
+            new DecapsKey($dhkem->curve, $skRm),
+            new EncapsKey($dhkem->curve, $pkSm),
+            $enc,
+            $psk,
+            $psk_id,
+            $info
+        );
+
         foreach ($encryptions as $hexTests) {
             $pt = sodium_hex2bin($hexTests['pt']);
             $ct = sodium_hex2bin($hexTests['ct']);

--- a/tests/KEM/DiffieHellmanKEMTest.php
+++ b/tests/KEM/DiffieHellmanKEMTest.php
@@ -17,14 +17,25 @@ use ParagonIE\HPKE\Interfaces\AEADInterface;
 use ParagonIE\HPKE\Interfaces\KDFInterface;
 use ParagonIE\HPKE\KDF\HKDF;
 use ParagonIE\HPKE\KEM\DHKEM\Curve;
+use ParagonIE\HPKE\KEM\DHKEM\DecapsKey;
 use ParagonIE\HPKE\KEM\DHKEM\EncapsKey;
 use ParagonIE\HPKE\KEM\DiffieHellmanKEM;
+use ParagonIE\HPKE\SymmetricKey;
+use ParagonIE\HPKE\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SodiumException;
 
 #[CoversClass(DiffieHellmanKEM::class)]
+#[CoversClass(HPKE::class)]
+#[CoversClass(AES256GCM::class)]
+#[CoversClass(HKDF::class)]
+#[CoversClass(Curve::class)]
+#[CoversClass(DecapsKey::class)]
+#[CoversClass(EncapsKey::class)]
+#[CoversClass(SymmetricKey::class)]
+#[CoversClass(Util::class)]
 class DiffieHellmanKEMTest extends TestCase
 {
     public static function rfc9180provider(): array


### PR DESCRIPTION
Currently, Auth and AuthPSK modes are not working at all: there are typos and small mistakes in code. These modes are not covered by tests, hence these problems are not visible. So, I've fixed these mishaps, and added tests for PSK, Auth and AuthPSK modes, using RFC9180 test vectors.

Also, most of the tests are failing due to insufficient coverage tags: tests are covering way more, than its specified. So, I've fixed this by adding appropriate coverage tags.

Now all the encryption modes are working according to RFC, and covered by tests.