### PR TITLE
Reject generator key in DHKEM EncapsKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /vendor
 /composer.lock
 /composer.phar
+/.phpunit.cache
+/.phpunit.result.cache

--- a/src/KEM/DHKEM/Curve.php
+++ b/src/KEM/DHKEM/Curve.php
@@ -8,8 +8,10 @@ use Mdanter\Ecc\Curves\SecureCurveFactory;
 use Mdanter\Ecc\Exception\InsecureCurveException;
 use Mdanter\Ecc\Primitives\CurveFpInterface;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
 use ParagonIE\EasyECC\EasyECC;
 use ParagonIE\HPKE\HPKEException;
+use SodiumException;
 
 enum Curve : string
 {
@@ -93,5 +95,23 @@ enum Curve : string
             self::NistP384 => 'P-384',
             self::NistP521 => 'P-521',
         };
+    }
+
+    /**
+     * @return string
+     * @throws HPKEException
+     * @throws InsecureCurveException
+     * @throws SodiumException
+     */
+    public function getGeneratorBytes(): string
+    {
+        if ($this === self::X25519) {
+            $generator = str_repeat("\x00", 32);
+            $generator[0] = "\x09";
+            return $generator;
+        }
+
+        $serializer = new UncompressedPointSerializer();
+        return sodium_hex2bin($serializer->serialize($this->getGenerator()));
     }
 }

--- a/src/KEM/DHKEM/EncapsKey.php
+++ b/src/KEM/DHKEM/EncapsKey.php
@@ -19,6 +19,8 @@ class EncapsKey implements EncapsKeyInterface
 {
     /**
      * @throws HPKEException
+     * @throws InsecureCurveException
+     * @throws SodiumException
      */
     public function __construct(
         public readonly Curve $curve,
@@ -27,6 +29,9 @@ class EncapsKey implements EncapsKeyInterface
     ){
         if (strlen($this->bytes) !== $this->curve->encapsKeyLength()) {
             throw new HPKEException('Invalid public key length');
+        }
+        if (hash_equals($this->curve->getGeneratorBytes(), $this->bytes)) {
+            throw new HPKEException('Encapsulation key matches the generator');
         }
     }
 

--- a/tests/KEM/DHKEM/EncapsKeyTest.php
+++ b/tests/KEM/DHKEM/EncapsKeyTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\HPKE\Tests\KEM\DHKEM;
+
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use ParagonIE\HPKE\KEM\DHKEM\Curve;
+use ParagonIE\HPKE\KEM\DHKEM\EncapsKey;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EncapsKey::class)]
+class EncapsKeyTest extends TestCase
+{
+    public function testRejectsGeneratorX25519(): void
+    {
+        // Generator for X25519 is 9.
+        $bytes = str_repeat("\x00", 32);
+        $bytes[0] = "\x09";
+
+        // This should throw an exception if we are rejecting the generator
+        $this->expectException(\Exception::class);
+        new EncapsKey(Curve::X25519, $bytes);
+    }
+
+    public function testRejectsGeneratorNistP256(): void
+    {
+        $curve = Curve::NistP256;
+        $generator = $curve->getGenerator();
+        $serializer = new UncompressedPointSerializer();
+        $bytes = hex2bin($serializer->serialize($generator));
+
+        $this->expectException(\Exception::class);
+        new EncapsKey($curve, $bytes);
+    }
+
+    public function testRejectsGeneratorSecp256k1(): void
+    {
+        $curve = Curve::Secp256k1;
+        $generator = $curve->getGenerator();
+        $serializer = new UncompressedPointSerializer();
+        $bytes = hex2bin($serializer->serialize($generator));
+
+        $this->expectException(\Exception::class);
+        new EncapsKey($curve, $bytes);
+    }
+
+    public function testRejectsGeneratorNistP384(): void
+    {
+        $curve = Curve::NistP384;
+        $generator = $curve->getGenerator();
+        $serializer = new UncompressedPointSerializer();
+        $bytes = hex2bin($serializer->serialize($generator));
+
+        $this->expectException(\Exception::class);
+        new EncapsKey($curve, $bytes);
+    }
+
+    public function testRejectsGeneratorNistP521(): void
+    {
+        $curve = Curve::NistP521;
+        $generator = $curve->getGenerator();
+        $serializer = new UncompressedPointSerializer();
+        $bytes = hex2bin($serializer->serialize($generator));
+
+        $this->expectException(\Exception::class);
+        new EncapsKey($curve, $bytes);
+    }
+}


### PR DESCRIPTION
Implemented rejection of generator key in EncapsKey constructor for all supported curves. Added regression tests.

---
*PR created automatically by Jules for task [11642557501375293525](https://jules.google.com/task/11642557501375293525) started by @paragonie-security*