### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "php": "^8.2",
     "ext-gmp": "*",
     "ext-openssl": "*",
-    "paragonie/sodium_compat": "^2",
     "paragonie/easy-ecc": "^1",
     "paragonie/ecc": "^2"
   },


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^2`, but also `php: ^8.2`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?